### PR TITLE
Undefined name: Error --> VergeMLError

### DIFF
--- a/vergeml/data.py
+++ b/vergeml/data.py
@@ -1,6 +1,7 @@
 from vergeml.utils import VergeMLError, parse_split
 from vergeml.views import ListView, BatchView, IteratorView
 from vergeml.io import Sample, SourcePlugin
+from vergeml.env import Environment
 from vergeml.operation import BaseOperation
 from vergeml.loader import FileCachedLoader, LiveLoader, MemoryCachedLoader
 from vergeml.plugins import PLUGINS
@@ -43,7 +44,7 @@ class Data:
     """
 
     def __init__(self,
-                 env: 'Environment' = None,
+                 env: Environment = None,
                  input: SourcePlugin = None,
                  output: SourcePlugin = None,
                  ops: List[BaseOperation] = [],

--- a/vergeml/sources/mnist.py
+++ b/vergeml/sources/mnist.py
@@ -62,7 +62,7 @@ class InputMnist(SourcePlugin):
 
         for path in files:
             if not os.path.exists(path):
-                raise Error("File not found in samples_dir: {}".format(
+                raise VergeMLError("File not found in samples_dir: {}".format(
                     os.path.basename(path)))
 
         if _md5(files[0]) == _MD5_FASHION:
@@ -101,7 +101,7 @@ class InputMnist(SourcePlugin):
                     n = int(len(self.data['train']) * self.config['val_perc'] // 100)
                 if n is not None:
                     if n > len(self.data['train']):
-                        raise Error("number of test samples is greater than number of available samples.")
+                        raise VergeMLError("number of test samples is greater than number of available samples.")
 
                     rng = random.Random(self.config['random_seed'])
                     count = len(self.data[split])
@@ -113,7 +113,7 @@ class InputMnist(SourcePlugin):
 
                 if self.config['test_num']:
                     if self.config['test_num'] > len(self.data['test']):
-                        raise Error("number of test samples is greater than number of available samples.")
+                        raise VergeMLError("number of test samples is greater than number of available samples.")
 
                     rng = random.Random(self.config['random_seed'])
                     indices = rng.sample(range(len(self.data[split])), len(pixels))


### PR DESCRIPTION
__Error__ is an undefined name in this context which can raise a NameError instead of the desired error.  This PR advocates changing __Error()__ --> __VergeMLError()__.  Another alternative would be __Exception()__.

[flake8](http://flake8.pycqa.org) testing of https://github.com/vergeml/vergeml on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./vergeml/data.py:46:23: F821 undefined name 'Environment'
                 env: 'Environment' = None,
                      ^
./vergeml/sources/mnist.py:65:23: F821 undefined name 'Error'
                raise Error("File not found in samples_dir: {}".format(
                      ^
./vergeml/sources/mnist.py:104:31: F821 undefined name 'Error'
                        raise Error("number of test samples is greater than number of available samples.")
                              ^
./vergeml/sources/mnist.py:116:31: F821 undefined name 'Error'
                        raise Error("number of test samples is greater than number of available samples.")
                              ^
4     F821 undefined name 'Environment'
4
```